### PR TITLE
Add venue and attending in person pages

### DIFF
--- a/content/attend/attending-in-person/contents.lr
+++ b/content/attend/attending-in-person/contents.lr
@@ -19,6 +19,25 @@ title: Food and Drinks
 ----
 hidden: False
 ----
-body: TBD
+body:
+### Watch the talks
+
+We have two areas for watching talks:
+- The main stage will be in the Fletcher Auditorium. This is the space where you can see the speakers live.
+- The Barrick Gold Lecture Room, room 1520, is our quiet room. Our live closed captioning will be turned on and the volume turned off. Lights will be dimmed. Any attendees in this room are expected to keep all noise to a minimum.
+
+### Food and Drinks
+
+As in previous years, we'll have coffee, tea, water, and snacks available in the morning and afternoon. For lunch, we take an extended break to allow attendees a chance to head out into Vancouver to enjoy the local fare.
+
+**No food or drinks are allowed in the Fletcher Auditorium**
+
+<!-- Update the link to the H&S policy when it's live -->
+### Outside the talks
+
+Feel free to stick around in the Segal Centre and Concourse to visit our sponsors or socialize before and after the conference. Keep in mind that our [Health and Safety Policy](https://2026.pycascades.com/about/the-conference/) and [Code of Conduct](https://2026.pycascades.com/about/code-of-conduct/) apply any time you're in the conference areas.
+
+### Nursing Room
+SFU has a nursing room on the campus in room 2179. This can be accessed through Campus Staff at 778 782-5029. Have an out of country SIM card? One of the organizers will be happy to get in touch with them for you. 
 ---
-_hidden: yes
+_hidden: no

--- a/content/attend/attending-in-person/contents.lr
+++ b/content/attend/attending-in-person/contents.lr
@@ -6,38 +6,26 @@ show_in_menu: yes
 ---
 sort_index: 1
 ---
-content:
-
-#### markdown ####
-title: Venue
-----
-hidden: False
-----
-body: For venue specific information, please see the [venue page](/attend/venue).
-#### markdown ####
-title: Food and Drinks
-----
-hidden: False
-----
 body:
-### Watch the talks
+
+## Watch the talks
 
 We have two areas for watching talks:
 - The main stage will be in the Fletcher Auditorium. This is the space where you can see the speakers live.
 - The Barrick Gold Lecture Room, room 1520, is our quiet room. Our live closed captioning will be turned on and the volume turned off. Lights will be dimmed. Any attendees in this room are expected to keep all noise to a minimum.
 
-### Food and Drinks
+## Food and Drinks
 
 As in previous years, we'll have coffee, tea, water, and snacks available in the morning and afternoon. For lunch, we take an extended break to allow attendees a chance to head out into Vancouver to enjoy the local fare.
 
 **No food or drinks are allowed in the Fletcher Auditorium**
 
 <!-- Update the link to the H&S policy when it's live -->
-### Outside the talks
+## Outside the talks
 
 Feel free to stick around in the Segal Centre and Concourse to visit our sponsors or socialize before and after the conference. Keep in mind that our [Health and Safety Policy](https://2026.pycascades.com/about/the-conference/) and [Code of Conduct](https://2026.pycascades.com/about/code-of-conduct/) apply any time you're in the conference areas.
 
-### Nursing Room
+## Nursing Room
 SFU has a nursing room on the campus in room 2179. This can be accessed through Campus Staff at 778 782-5029. Have an out of country SIM card? One of the organizers will be happy to get in touch with them for you. 
 ---
 _hidden: no

--- a/content/attend/contents.lr
+++ b/content/attend/contents.lr
@@ -2,4 +2,6 @@ _model: page
 ---
 title: Attend
 ---
-_hidden: yes
+_hidden: no
+---
+_discoverable: no

--- a/content/attend/venue/contents.lr
+++ b/content/attend/venue/contents.lr
@@ -1,11 +1,28 @@
 _model: page
 ---
-title: Venue
----
-body: 
+title: About Vancouver
 ---
 show_in_menu: yes
 ---
+body: 
+### Segal Centre
+The Joseph & Rosalie Segal Centre is a building within the Simon Fraser University, Harbour Centre campus. SFU opened its Harbour Centre campus in 1989. As BC’s first urban campus, it marked a new era in post-secondary education. Situated in the heart of downtown Vancouver, Harbour Centre offers a variety of meeting, classroom, reception, and laboratory spaces.
+
+### Public Transit
+Major public transit lines, the SeaBus, SkyTrain and WestCoast Express terminate at Waterfront Station, located in the historic CP Rail Station on Cordova Street, opposite Simon Fraser University at Harbour Centre. Transit schedules can be found at www.translink.ca. The Centre is also within easy walking distance of all street buses with a terminus in downtown Vancouver.
+
+### Driving from Vancouver International Airport (YVR)
+From the airport, proceed north along the Arthur Laing Bridge to Granville Street. Head north on Granville Street into downtown Vancouver. After crossing the Granville Street Bridge, take the Seymour Street exit and continue north on Seymour until Hastings. Harbour Centre is located on Hastings Street, between Seymour and Richards.
+
+### Parking
+Public parking is available at many locations near the Centre. Street parking is free after 10 pm. The closest parking lot is at 400 West Cordova Street. Here is a list of [impark lots nearby](https://lots.impark.com/IMP/en?latlng=49.28432512044114,-123.11095830783042&zoom=17#).
+
+### Hotels
+There are a large number of hotels in the downtown area within walking distance of the Harbour Centre. The Centre is located close to all forms of public transit so hotels outside of the downtown core are a viable option as well.
+
+[Here is a list of hotels near the Harbour Centre](https://www.google.com/maps/search/hotels/@49.2846728,-123.1138545,17z/data=!3m1!4b1?entry=ttu&g_ep=EgoyMDI2MDEwNy4wIKXMDSoKLDEwMDc5MjA3MUgBUAM%3D).
+
+---
 sort_index: 0
 ---
-_hidden: yes
+_hidden: no


### PR DESCRIPTION
Added venue as About Vancouver because the Venue page from 2023 was about Vancouver not the venue specifically. 

Added an attending-in-person page. Please add to this, I know we have some extra events happening like the one with Microsoft.