### PR TITLE
Update grants FAQ to reference Canada and 2026

### DIFF
--- a/content/about/grants/contents.lr
+++ b/content/about/grants/contents.lr
@@ -33,11 +33,11 @@ A: The costs covered by the Grant award may include some or all of the below:
 
 * Travel:
   * Transit receipts: taxi, bus, train, and mileage to/from airport, bus station, train station, lodging or conference center, and parking at these locations.
-  * Driving: We will be following the 2024 IRS mileage rate. Please be sure to provide a PDF or an image of the mileage for your trip. Please do not submit gas receipts.
+  * Driving: We will be following the 2026 IRS mileage rate. Please be sure to provide a PDF or an image of the mileage for your trip. Please do not submit gas receipts.
   * Airfare including baggage fees for travel to/from the conference.
 * Lodging: hotels, motels, hostels, AirBnB, etc. for the days you attend the conference. Reimbursement is limited to the shared cost if the room has more than one occupant.
 * Food (Per Diem): covers food during the days you attend the conference plus a travel day at the beginning and end of your trip at a fixed rate. Please do not upload food receipts. Per-diems are automatically granted to you based on the days that you are attending PyCascades, plus up to one travel day before and after conference attendance.
-* Visa fees: if you are a non US national and must have a visa to attend the conference.
+* Visa fees: if you are a non Canadian national and must have a visa to attend the conference.
 * Tickets: a free ticket or a refund on the ticket cost.
 
 The following costs are not covered by the grant:
@@ -46,8 +46,8 @@ The following costs are not covered by the grant:
 * On-board/Airport/Hotel WiFi Charges
 * Cellular roaming/international charges
 
-### Q: What if I need help with a US visitor visa?
-A: We can provide you with an “Invitation Letter” upon request, in support of an application for a United States visitor visa. It confirms that as a registered delegate you are invited to attend PyCascades by the Python Software Foundation (PSF) and the PyCascades 2024 committee.
+### Q: What if I need help with a visitor visa to Canada?
+A: We can provide you with a [Letter of Invitation](https://www.canada.ca/en/immigration-refugees-citizenship/services/visit-canada/letter-invitation.html) upon request, in support of an application for a visitor visa. It confirms that as a registered delegate you are invited to attend PyCascades by the Python Software Foundation (PSF) and the PyCascades 2026 committee.
 
 ### Q: What if I don’t come to PyCascades?
 A: If you do not register and attend PyCascades, you will not receive your grant. Please notify the Grants Committee that you cannot attend.


### PR DESCRIPTION
Mostly update the letter of invitation to specify Canada not the US, since we're not in the US this year.

Also update the mileage rate to reference 2026 - though maybe we want to use the old rate?